### PR TITLE
fix for infinite loop if you include whitespace in the filter

### DIFF
--- a/standalone/FilteredListProvider.cs
+++ b/standalone/FilteredListProvider.cs
@@ -164,7 +164,12 @@ namespace OpenFileFromDir
 
                 var cflt = filter[iflt];
 
-                if (char.IsWhiteSpace(cflt)) continue; // ignore spaces
+                if (char.IsWhiteSpace(cflt))
+                {
+                    // ignore spaces
+                    ++iflt;
+                    continue;
+                }
 
                 // the filter comes from the user
                 // it can contain forward slashes which we want to match with backcslashes


### PR DESCRIPTION
The loop never terminated if you type e.g. a space into the filter box.